### PR TITLE
WIP: Update to latest geo (customizable metric spaces)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ geojson = { git = "https://github.com/georust/geojson", features = ["geo-types"]
 log = "0.4"
 osm-reader = { git = "https://github.com/a-b-street/osm-reader" }
 serde = { version = "1.0", features = ["derive"], optional = true }
+
+[patch.crates-io]
+geo = { git = "https://github.com/georust/geo" } 

--- a/src/line_split/measure_line_string.rs
+++ b/src/line_split/measure_line_string.rs
@@ -35,7 +35,7 @@ where
              mut length_segments,
          },
          current| {
-            let segment_length = current.length::<Euclidean>();
+            let segment_length = Euclidean.length(&current);
             length_segments.push(segment_length);
             LineStringMeasurements {
                 length_total: length_total + segment_length,

--- a/src/mercator.rs
+++ b/src/mercator.rs
@@ -20,16 +20,14 @@ impl Mercator {
     /// Create a boundary covering some geometry
     pub fn from<T: BoundingRect<f64>>(geometry: T) -> Option<Self> {
         let wgs84_bounds = geometry.bounding_rect().into()?;
-        let width = LineString::from(vec![
+        let width = Haversine.length(&LineString::from(vec![
             (wgs84_bounds.min().x, wgs84_bounds.min().y),
             (wgs84_bounds.max().x, wgs84_bounds.min().y),
-        ])
-        .length::<Haversine>();
-        let height = LineString::from(vec![
+        ]));
+        let height = Haversine.length(&LineString::from(vec![
             (wgs84_bounds.min().x, wgs84_bounds.min().y),
             (wgs84_bounds.min().x, wgs84_bounds.max().y),
-        ])
-        .length::<Haversine>();
+        ]));
         Some(Self {
             wgs84_bounds,
             width,


### PR DESCRIPTION
I don't know that we need to merge this yet, but *eventually* when we update geo there will be some breaking changes, fixed in this PR.

As a side note:

The test suite is currently broken - it seems to be referencing some non-existent `offset` methods.

```
error[E0599]: no method named `offset_curve` found for struct `geo::MultiLineString` in the current scope
   --> src/offset_curve/offset_curve_trait.rs:308:35
    |
64  |     fn offset_curve(&self, distance: T) -> Option<Self>;
    |        ------------ the method is available for `geo::MultiLineString` here
...
308 |         let output_actual = input.offset_curve(-1f64);
    |                                   ^^^^^^^^^^^^ method not found in `MultiLineString`
```